### PR TITLE
FIX: Updated gitignore with additional IntelliJ file excluding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,9 @@ local.properties
 
 # Locally stored "Eclipse launch configurations"
 *.launch
+
+# Intellij
+.idea/
+*.iml
+*.iws
+


### PR DESCRIPTION
Added new entries in the .gitignore for excluding files that are generated by IntelliJ. The reason for this exclusion is that those files can harm someones environment. 