### PR TITLE
ci: use java 1.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,15 @@
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.5.1</version>
+				<configuration>
+					<source>1.8</source>
+					<target>1.8</target>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
 				<version>2.4</version>
 				<configuration>


### PR DESCRIPTION
Because by default Maven uses 1.5 which is like a million years old.