### PR TITLE
cli: add "headless" mode, fixes #34

### DIFF
--- a/src/nl/hanze/gameserver/app/Application.java
+++ b/src/nl/hanze/gameserver/app/Application.java
@@ -31,8 +31,15 @@ public class Application {
 	
 	private GameServer gameServer;
 	private GameServerGUI gameServerGui;
-	
+
+	private boolean useGui = true;
+
 	private Application() {
+		this(new String[] {});
+	}
+
+	private Application(String[] cliArgs) {
+		parseCliArgs(cliArgs);
 		initialize();
 		
 		closing = false;
@@ -50,14 +57,25 @@ public class Application {
 		
 		try {
 			gameServer = new GameServer();
-			gameServerGui = new GameServerGUI(gameServer);
+			if (useGui) {
+				gameServerGui = new GameServerGUI(gameServer);
+			}
 		} catch (IOException e) {
 			Log.ERROR.printf("Error while instantiating GameServer: %s", e);
 			
 			exit();
 		}
 	}
-	
+
+	private void parseCliArgs(String[] cliArgs) {
+		for (String cliArg : cliArgs) {
+			System.out.println(cliArg);
+			if (cliArg.equals("--headless")) {
+				useGui = false;
+			}
+		}
+	}
+
 	private void initialize() {
 		shortName = "StrategicGameServer";
 		name = "Strategic Game Server";
@@ -135,7 +153,7 @@ public class Application {
 	}
 	
 	public static void main(String[] args) {
-		getInstance();
+		instance = new Application(args);
 		Log.DEBUG.println("Application started");
 	}
 }


### PR DESCRIPTION
This patch adds a --headless argument to the game server CLI, that
disables the GUI.

It's a little bit hacky—the CLI args are passed to the Application
constructor, by bypassing the Application singleton's `getInstance`
method.

An alternative solution would be to parse the CLI args into (a)
static `options` variable(s), and have the Application instance
use that. Then the options are global but we'd be agnostic about
the existence of the Application instance in the `main()` method.